### PR TITLE
fix. return hashtags by quantity order on trending

### DIFF
--- a/src/repositories/hashtagRepository.js
+++ b/src/repositories/hashtagRepository.js
@@ -24,10 +24,11 @@ export function linkHashtags(postId, hashtagId) {
 
 export function getTrendingHashtags() {
   return db.query(`
-    SELECT h.name, h.id, COUNT(h.id) AS quantity
-    FROM "publicationsHashtags" ph
-    JOIN hashtags h ON ph."hashtagId" = h.id
-    GROUP BY(H.ID)
+    SELECT h.name, COUNT(h.name) AS quantity
+    FROM hashtags h
+    JOIN "publicationsHashtags" ph ON ph."hashtagId" = h.id
+    JOIN publications p ON p.id = ph."publicationId"
+    GROUP BY(H.name)
     ORDER BY quantity DESC
     LIMIT 10
   `)


### PR DESCRIPTION
Antes, o COUNT estava dando 1 para todas as hashtags então retornava de forma aleatória, alterei para contar pelo nome da hashtag e está funcionando.