### PR TITLE
fix. changed property name from linkTilte to linkTitle

### DIFF
--- a/src/controllers/timelineController.js
+++ b/src/controllers/timelineController.js
@@ -26,7 +26,7 @@ export async function Timeline(_req, res) {
                     link: info.link,
                     description: info.description,
                     linkPicture: response.picture,
-                    linkTilte: response.title,
+                    linkTitle: response.title,
                     linkDescription: response.description
                 }
                 postsArray.push(publicationsInfos)
@@ -39,7 +39,7 @@ export async function Timeline(_req, res) {
                     link: info.link,
                     description: info.description,
                     linkPicture: undefined,
-                    linkTilte: undefined,
+                    linkTitle: undefined,
                     linkDescription: undefined
                 }
                 postsArray.push(publicationsInfos)


### PR DESCRIPTION
Pequena correção na nomenclatura de uma propriedade que fazia com que todos os titulos da timeline viessem como undefined.